### PR TITLE
Adding filestore stats : num_bytes_written, num_events_written per categ...

### DIFF
--- a/debian_hdfs/changelog
+++ b/debian_hdfs/changelog
@@ -1,8 +1,14 @@
+scribe-server-hdfs-orig (0.3) lucid; urgency=low
+
+  * provide num_messages writte and num_bytes written to a file store
+
+ -- Platform Engineering <platform-engg@inmobi.com> Mon, 29 Oct 2012 12:10:45  +0530
+
 scribe-server-hdfs-orig (0.2.8-1) lucid; urgency=low
 
   * write queue size to scribe log when a request in throttled.
 
- -- Platform Engineering <platform-engg@inmobi.com> Fri, 12 Oct 2012 11:37:00  +0530 
+ -- Platform Engineering <platform-engg@inmobi.com> Fri, 12 Oct 2012 11:37:00  +0530
 
 scribe-server-hdfs-orig (0.2.7-1) lucid; urgency=low
 

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -560,8 +560,8 @@ void FileStoreBase::printStats() {
   LOG_OPER("[%s]", log_str.c_str());
   /*stats_file->write(msg.str());*/
   // update the stats
-  g_Handler->incCounter(categoryHandled, fsType + ":wrote num messages", eventsWritten);
-  g_Handler->incCounter(categoryHandled, fsType + ":wrote bytes", currentSize);  
+  g_Handler->incCounter(categoryHandled, fsType + "_wrote_num_messages", eventsWritten);
+  g_Handler->incCounter(categoryHandled, fsType + "_wrote_bytes", currentSize);  
   stats_file->close();
 }
 

--- a/src/store.cpp
+++ b/src/store.cpp
@@ -558,8 +558,10 @@ void FileStoreBase::printStats() {
 
   string log_str = msg.str();
   LOG_OPER("[%s]", log_str.c_str());
-
   /*stats_file->write(msg.str());*/
+  // update the stats
+  g_Handler->incCounter(categoryHandled, fsType + ":wrote num messages", eventsWritten);
+  g_Handler->incCounter(categoryHandled, fsType + ":wrote bytes", currentSize);  
   stats_file->close();
 }
 


### PR DESCRIPTION
# Sample Metrics available through fix

<categoryName>:<storeType>:<Metrics> : <Value>
benchmark_test_collector:received good: 4000
benchmark_test_collector:hdfs:wrote num messages: 4000
benchmark_test_collector:hdfs:wrote bytes: 20016
# Explanation

here "benchmark_test_collector" is the stream name followed by store type
"hdfs" and then "wrote num messages" and "wrote bytes" is the name of the
metrics for hdfs file store.
# Alerting scenario

for each stream in collector if received_good and "<category>:hdfs:wrote num
messages" don't overlap in a minute lag then raise an alert.
# Can these be enabled for spool store?

Yes, by including write_stats=yes in the secondary store config of
agent/collector

You should see metrics like following for spool store also

benchmark_test_collector:std:wrote num messages: 1834
benchmark_test_collector:std:wrote bytes: 13786

P.S. -> categoryName followed by Store Type in this case it's std i.e.
localFileSystem for spooling.
Note fsType std instead of hdfs

I want to check that collector is healthy without going into category level
# details?

Use scribe_overall:std:wrote num messages and compare it
scribe_overall:received good after a minute boundary they should overlap
# Is it mandatory to enable these stats for secondary/spool store?

Not really, 

For Databus Collectors
the difference between scribe_overall:received_good and "scribe_overall:wrote
num message" is the number of messages spooled

For Databus Agents
the difference between scribe_overall:received_good and scribe_overall:sent  is
the number of messages spooled.
# How do i know that databus collector/agent is not responding properly

If spooling happens then the difference between the above explained metrics
should go away once de-spooled if that's not happening and events aren't
getting spooled then there is a problem with agent/collector(Press the PANIC
BUTTON)
