### PR TITLE
Add missing change logs in scribe non-hdfs server build

### DIFF
--- a/debian_hdfs/changelog
+++ b/debian_hdfs/changelog
@@ -1,14 +1,14 @@
 scribe-server-hdfs-orig (0.3) lucid; urgency=low
 
-  * provide num_messages writte and num_bytes written to a file store
+  * provide num_messages written and num_bytes written to a file store
 
- -- Platform Engineering <platform-engg@inmobi.com> Mon, 29 Oct 2012 12:10:45  +0530
+ -- Platform Engineering <platform-engg@inmobi.com>  Mon, 29 Oct 2012 12:10:45  +0530
 
 scribe-server-hdfs-orig (0.2.8-1) lucid; urgency=low
 
   * write queue size to scribe log when a request in throttled.
 
- -- Platform Engineering <platform-engg@inmobi.com> Fri, 12 Oct 2012 11:37:00  +0530
+ -- Platform Engineering <platform-engg@inmobi.com>  Fri, 12 Oct 2012 11:37:00  +0530
 
 scribe-server-hdfs-orig (0.2.7-1) lucid; urgency=low
 

--- a/debian_nonhdfs/changelog
+++ b/debian_nonhdfs/changelog
@@ -1,3 +1,27 @@
+scribe-server-orig (0.3) lucid; urgency=low
+
+  * provide num_messages written and num_bytes written to a file store
+
+ -- Platform Engineering <platform-engg@inmobi.com>  Mon, 29 Oct 2012 12:10:45  +0530
+
+scribe-server-orig (0.2.8-1) lucid; urgency=low
+
+  * write queue size to scribe log when a request in throttled.
+
+ -- Platform Engineering <platform-engg@inmobi.com>  Fri, 12 Oct 2012 11:37:00  +0530
+
+scribe-server-orig (0.2.5-1) lucid; urgency=low
+
+  * write stats to scribe server log
+
+ -- Platform Engineering <platform-engg@inmobi.com>  Wed, 25 Jul 2012 17:57:45 +0530
+
+scribe-server-orig (0.2.4-1) lucid; urgency=low
+
+  * Don't Write Scribe_stats file even when the setting contains to write it
+
+ -- Platform Engineering <platform-engg@inmobi.com>  Wed, 25 Jul 2012 17:57:45 +0530
+
 scribe-server-orig (0.2.2-1) lucid; urgency=low
 
   * added metrics to capture per category timesouts and eofs for the network store


### PR DESCRIPTION
1) The relevant change logs are migrated from debian_hdfs/changelog to debian_nonhdfs/changelog

2) The version of debian_nonhdfs is brought up to 0.3, same as debian_hdfs.
