### PR TITLE
Fix compilation issue due to CDH3u5 upgrade

### DIFF
--- a/debian_hdfs/changelog
+++ b/debian_hdfs/changelog
@@ -1,3 +1,9 @@
+scribe-server-hdfs-orig (0.4.2) lucid; urgency=low
+
+  * Fix compilation issue due to CDH3u5 upgrade
+
+ -- Platform Engineering <platform-engg@inmobi.com>  Wed, 03 Apr 2013 17:01:00  +0530
+
 scribe-server-hdfs-orig (0.4.1) lucid; urgency=low
 
   * Increment audit messages generated counter; Increment sent counter per topic in Network Store

--- a/src/HdfsFile.cpp
+++ b/src/HdfsFile.cpp
@@ -153,7 +153,7 @@ unsigned long HdfsFile::fileSize() {
 
 void HdfsFile::deleteFile() {
   if (fileSys) {
-    hdfsDelete(fileSys, filename.c_str());
+    hdfsDelete(fileSys, filename.c_str(), 0);
   }
   LOG_OPER("[hdfs] deleteFile %s", filename.c_str());
 }


### PR DESCRIPTION
In CDH3u5, there is an interface change for the method hdfsDelete() inside hdfs.h. It takes an extra argument called recursive, which is applicable for directory only.
