### PR TITLE
Scribe log messages should have millisecond level timestamp

### DIFF
--- a/src/env_default.h
+++ b/src/env_default.h
@@ -59,13 +59,12 @@ const std::string scribeversion("2.2");
  */
 #define LOG_OPER(format_string,...)                                     \
   {                                                                     \
-    time_t now;                                                         \
-    char dbgtime[26] ;                                                  \
-    time(&now);                                                         \
-    ctime_r(&now, dbgtime);                                             \
-    dbgtime[24] = '\0';                                                 \
     struct timeval tv;                                                  \
     gettimeofday(&tv, NULL);                                            \
+    time_t now = tv.tv_sec;                                             \
+    char dbgtime[26] ;                                                  \
+    ctime_r(&now, dbgtime);                                             \
+    dbgtime[24] = '\0';                                                 \
     long numMillis = (tv.tv_usec / 1000);                               \
     fprintf(stderr,"[%s %ld] " #format_string " \n", dbgtime,numMillis,##__VA_ARGS__); \
   }

--- a/src/env_default.h
+++ b/src/env_default.h
@@ -64,7 +64,10 @@ const std::string scribeversion("2.2");
     time(&now);                                                         \
     ctime_r(&now, dbgtime);                                             \
     dbgtime[24] = '\0';                                                 \
-    fprintf(stderr,"[%s] " #format_string " \n", dbgtime,##__VA_ARGS__); \
+    struct timeval tv;                                                  \
+    gettimeofday(&tv, NULL);                                            \
+    long numMillis = (tv.tv_usec / 1000);                               \
+    fprintf(stderr,"[%s %ld] " #format_string " \n", dbgtime,numMillis,##__VA_ARGS__); \
   }
 
 


### PR DESCRIPTION
Sample log : [Wed Aug 13 15:59:14 2014 486] "throttle denying request for queue size <31681> with a batch of" " <1> messages for [benchmark_collector] category. It would exceed max queue size <30000>" 
