### PR TITLE
fix-43: make num_store_threads as  'signed long int'  

### DIFF
--- a/src/conf.cpp
+++ b/src/conf.cpp
@@ -86,6 +86,17 @@ bool StoreConf::getUnsigned(const string& intName,
   }
 }
 
+bool StoreConf::getSigned(const string& intName,
+                          signed long int& _return) const {
+  string str;
+  if (getString(intName, str)) {
+    _return = strtol(str.c_str(), NULL, 0);
+    return true;
+  } else {
+    return false;
+  }
+}
+
 bool StoreConf::getUnsignedLongLong(const string& llName,
                                     unsigned long long& _return) const {
   string str;

--- a/src/conf.h
+++ b/src/conf.h
@@ -51,6 +51,7 @@ class StoreConf {
   bool getStore(const std::string& storeName, pStoreConf& _return);
   bool getInt(const std::string& intName, long int& _return) const;
   bool getUnsigned(const std::string& intName, unsigned long int& _return) const;
+  bool getSigned(const std::string& intName, signed long int& _return) const;
   bool getUnsignedLongLong(const std::string& intName, unsigned long long& _return) const;
   bool getFloat(const std::string& floatName, float & _return) const;
   bool getString(const std::string& stringName, std::string& _return) const;

--- a/src/scribe_server.cpp
+++ b/src/scribe_server.cpp
@@ -930,18 +930,21 @@ bool scribeHandler::configureStore(pStoreConf store_conf, int *numstores) {
 			category[category.size() - 1] == '*');
     bool is_default_category = (!category.empty() && category.compare("default") == 0);
 
-    unsigned long int num_store_threads = -1;
-    if (!store_conf->getUnsigned("num_store_threads", num_store_threads)
-      || is_default_category || is_prefix_category || (num_store_threads <= 1)) {
+    signed long int num_store_threads = -1;
+    if (is_default_category || is_prefix_category
+       || (!store_conf->getSigned("num_store_threads", num_store_threads)
+       || (num_store_threads <= 1))) {
       shared_ptr<StoreQueue> result =
         configureStoreCategory(store_conf, category, model);
       if (result == NULL) {
+        LOG_OPER("Unable to create store queue for [%s] category", category.c_str());
         return false;
       }
     } else {
       const char* category_str = category.c_str();
-      LOG_OPER("Configuring [%lu] store queues for [%s] ", num_store_threads, category_str);
-      for (std::size_t i = 0; i < num_store_threads; i++) {
+      LOG_OPER("Configuring [%ld] store queues for [%s] ", num_store_threads, category_str);
+      signed long int i;
+      for (i = 0; i < num_store_threads; i++) {
         ostringstream ostr;
         ostr << "thread_" << i;
         const std::string thread_name = ostr.str();


### PR DESCRIPTION
Add getSigned() method in conf.cpp to get the 'signed long int' value. If user configures negative value to this property then scribe will starts with single writer thread for that category
